### PR TITLE
Remove unused ms dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -851,11 +851,6 @@
         "supports-color": "5.4.0"
       }
     },
-    "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,7 @@
     "prepublish": "tsc",
     "test": "istanbul cover _mocha"
   },
-  "dependencies": {
-    "ms": "~0.7.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/bluebird": "^3.5.24",
     "@types/ms": "^0.7.30",

--- a/src/Disyuntor.ts
+++ b/src/Disyuntor.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'events'
-import ms from 'ms'
 
 import { Options } from './Options';
 import { DisyuntorError } from './DisyuntorError';


### PR DESCRIPTION
The PR removes the unused `ms` dependency which has a low severity issue: https://app.snyk.io/vuln/npm:ms:20170412