### PR TITLE
Update ms to non vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -852,9 +852,9 @@
       }
     },
     "ms": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "istanbul cover _mocha"
   },
   "dependencies": {
-    "ms": "~0.7.1"
+    "ms": "^2.1.1"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.24",


### PR DESCRIPTION
The PR updates ms dependency to a non vulnerable major version. The current version has a low severity issue: https://app.snyk.io/vuln/npm:ms:20170412