### PR TITLE
Disyuntor max cooldown NaN reproduce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "disyuntor",
   "description": "A circuit-breaker implementation with exponential backoff.",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "repository": {
     "url": "git://github.com/jfromaniello/disyuntor.git"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "prepublish": "tsc",
-    "test": "istanbul cover _mocha"
+    "test": "npm run build && istanbul cover _mocha"
   },
   "dependencies": {
     "ms": "^2.1.1"

--- a/test/disyuntor.test.js
+++ b/test/disyuntor.test.js
@@ -453,4 +453,30 @@ describe('disyuntor', function () {
 
     });
   });
+
+  describe('currentCooldown NaN issue', function() {
+    /*
+    Tests that when no maxCooldown is provided that currentCooldown
+    is not NaN
+     */
+    it('current cooldown not NaN on half-open', function(done) {
+        const disyuntor = new Disyuntor({
+            name: 'disyuntor test',
+            maxFailures: 1,
+            cooldown: 1,
+        });
+
+        // set failures to 1 in order to force an state transition to either (Open|HalfOpen)
+        disyuntor.failures = 1;
+        // trigger disyuntor HalfOpen state in order to trigger currentCooldown calculation
+        disyuntor.currentCooldown = -Infinity;
+        disyuntor.protect(() => {
+            throw new Error('error 1');
+        }).catch(() => {
+        }).then(() => {
+          assert.equal(-Infinity, disyuntor.currentCooldown);
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
Sets a default `maxCooldown` which should prevent getting stuck in a `HalfOpen` state.

Consider disyuntor in a HalfOpen state with no `maxCooldown` set:
- `maxCooldown` [gets assigned](https://github.com/auth0/disyuntor/blob/v3.4.2/src/Disyuntor.ts#L93) a value of `undefined`
- `HalfOpen` state [gets entered](https://github.com/auth0/disyuntor/blob/v3.4.2/src/Disyuntor.ts#L79) (failing a large amount of times in a short `cooldown` period)
- `currentCooldown` [is recalculated](https://github.com/auth0/disyuntor/blob/v3.4.2/src/Disyuntor.ts#L92)
```
  this.currentCooldown = Math.min(
          this.currentCooldown * (this.failures + 1),
          <number>this.params.maxCooldown
      );
```
- `currentCooldown` picks up value of `NaN` because of `maxCooldown` being undefined
```
Math.min(10 * (5 + 1), undefined);
NaN
```
- while in a failing state, The state calculation to see if the cooldown has passed will not reach true since a [number is being compared](https://github.com/auth0/disyuntor/blob/v3.4.2/src/Disyuntor.ts#L76) to `NaN`:
```
  if (timeSinceLastFailure < this.currentCooldown) {
        return State.Open;
      } else {
```
```
10 < NaN
false
```
- This results in Dysuntor should be transitioning to Open in order to temporarily prohibit actions but instead it is in `HalfOpen` and actually executes the call on the next call

-----

The `NaN` is reproduced with the following test:


```
$ npm run build && ./node_modules/mocha/bin/_mocha -g "current cooldown not NaN on half-open"

> disyuntor@3.4.2 build /Users/danielmican/code/github.com/auth0/disyuntor
> tsc



  disyuntor
    currentCooldown NaN issue
timeSinceLastFailure:  1547672043287
state:  half open
cooldown:  -Infinity
currentCooldown:  NaN
      1) current cooldown not NaN on half-open


  0 passing (9ms)
  1 failing

  1) disyuntor
       currentCooldown NaN issue
         current cooldown not NaN on half-open:
     AssertionError: expected -Infinity to equal NaN
      at disyuntor.protect.catch.finally (test/disyuntor.test.js:478:18)
      at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:68:7)

```

----
After adding a default `maxCooldown` NaN is no longer reached:
```
const defaults = {
  ...
  maxCooldown: '60s',
  ...
};
```
```
$ npm run build && ./node_modules/mocha/bin/_mocha -g "current cooldown not NaN on half-open"

> disyuntor@3.4.2 build /Users/danielmican/code/github.com/auth0/disyuntor
> tsc



  disyuntor
    currentCooldown NaN issue
timeSinceLastFailure:  1547672247914
state:  half open
cooldown:  -Infinity
currentCooldown:  -Infinity
      ✓ current cooldown not NaN on half-open


  1 passing (7ms)
```