### PR TITLE
fix: calculate backoff based on trip count instead of failures

### DIFF
--- a/src/Disyuntor.ts
+++ b/src/Disyuntor.ts
@@ -117,7 +117,7 @@ export class Disyuntor extends EventEmitter {
           this.emit('trip',
             err,
             this.failures,
-            this.currentCooldown,
+            this.currentCooldown
           );
         }
       }

--- a/src/Disyuntor.ts
+++ b/src/Disyuntor.ts
@@ -105,7 +105,7 @@ export class Disyuntor extends EventEmitter {
       }
 
       //If it worked we need to reset it, regardless if is half-open or closed,
-      ///the failures counter is meant to accumulate failures in a row.
+      //the failures counter is meant to accumulate failures in a row.
       this.reset();
 
       return result;


### PR DESCRIPTION
### Description

Per referenced ticket, the current backoff strategy was increasing to the maximum too quickly as it referenced the number of failed calls instead of the number of circuit breaker trips when computing the cooldown time. This PR updates the cooldown calculation to the desired behavior.
 
### References

https://auth0team.atlassian.net/browse/IAMRISK-2169

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
